### PR TITLE
Fix typo in path

### DIFF
--- a/catalogs/hpc2020/catalog/EC-EARTH4/e486.yaml
+++ b/catalogs/hpc2020/catalog/EC-EARTH4/e486.yaml
@@ -26,7 +26,7 @@ sources:
       source_grid_name: eORCA1-ece
       fixer_name: ec-earth4-nemo
     args:
-      urlpath: '/perm/smw/ece-4-exps/PR04/output/nemo/PR04_oce_1m_T_*.nc'
+      urlpath: '/perm/smw/ece-4-exps/E486/nemo/E486_oce_1m_T_*.nc'
       chunks:
         time_counter: 1
       xarray_kwargs:


### PR DESCRIPTION
This just fixes a minor typo in a path of a specific sample catalogue