### PR TITLE
Regrid option in AQUA analysis default

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ Instructions:
 
 EC-Earth4 sources are now availble from the EC-EARTH4 model, your experiment identifier and one of the sources defined in the catalogue (such as ``monthly-atm``).
 
-Next you can modify to your needs the job template in ``jobs/aqua_analysis_e486.job`` and run your first AQUA analysis.
+Next you can modify to your needs the job template in ``jobs/aqua_analysis.tmpl`` and run your first AQUA analysis.
 
 Currently to add a new experiments you can use the catalogue generator in the ``catalog-generator`` folder.

--- a/config/cli/config.aqua-analysis.atm.yaml
+++ b/config/cli/config.aqua-analysis.atm.yaml
@@ -102,17 +102,12 @@ diagnostics:
   teleconnections_atm:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 8
-    # Command line extra arguments for teleconnections:
-    # --dry, -d (dry run, if set it will run without producing plots)
-    # --ref (if set it will analyze also the reference data, it is set
-    #        by default)
-    # --interface (custom interface file)
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_atm.yaml"
+    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_atm.yaml"
     outname: teleconnections
   teleconnections_oce:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 4
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_oce.yaml"
+    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_oce.yaml"
     outname: teleconnections
   tropical_rainfall:
     nworkers: 16

--- a/config/cli/config.aqua-analysis.atm.yaml
+++ b/config/cli/config.aqua-analysis.atm.yaml
@@ -28,9 +28,9 @@ job:
 
     # Default values, overriden from command line arguments
     catalog: null  # The catalog to use for the analysis
-    model: "IFS-NEMO"
-    exp: "historical-1990"
-    source: "lra-r100-monthly"
+    model: null
+    exp: null
+    source: null
 
     script_path_base: "${AQUA}/diagnostics"  # Base directory for the diagnostic scripts
 
@@ -68,7 +68,6 @@ diagnostics:
   global_biases:
     nworkers: 16
     script_path: "../src/aqua_diagnostics/global_biases/cli_global_biases.py"
-    extra: "--regrid F128"
     config: "${AQUA_CONFIG}/diagnostics/global_biases/cli/config_global_biases.yaml"
   timeseries_atm:
     script_path: "../src/aqua_diagnostics/timeseries/cli_timeseries.py"
@@ -88,7 +87,6 @@ diagnostics:
   radiation-biases:
     script_path: "../src/aqua_diagnostics/global_biases/cli_global_biases.py"
     nworkers: 8
-    extra: "--regrid F128"
     config: "${AQUA_CONFIG}/diagnostics/radiation/cli/config_radiation-biases.yaml"
     outname: radiation
   radiation-boxplots:
@@ -110,13 +108,11 @@ diagnostics:
     #        by default)
     # --interface (custom interface file)
     config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_atm.yaml"
-    extra: "--ref --regrid F128"
     outname: teleconnections
   teleconnections_oce:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 4
     config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_oce.yaml"
-    extra: "--ref --regrid F128"
     outname: teleconnections
   tropical_rainfall:
     nworkers: 16
@@ -130,12 +126,10 @@ diagnostics:
   ocean3d_drift:
     script_path: "ocean3d/cli/cli_ocean3d.py"
     nworkers: 8
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.drift.yaml"
   ocean3d_circulation:
     script_path: "ocean3d/cli/cli_ocean3d.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.circulation.yaml"
   seaice_volume:
     script_path: "seaice/cli/cli_seaice.py"
@@ -145,20 +139,16 @@ diagnostics:
     #               (default is False)
     # --config (seaice config file)
     # --regrid (regrid data to a different grid)
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Volume.yaml"
   seaice_thick:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Thickness.yaml"
   seaice_conc:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Concentration.yaml"
   seaice_extent:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Extent.yaml"

--- a/config/cli/config.aqua-analysis.ice.yaml
+++ b/config/cli/config.aqua-analysis.ice.yaml
@@ -99,17 +99,12 @@ diagnostics:
   teleconnections_atm:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 8
-    # Command line extra arguments for teleconnections:
-    # --dry, -d (dry run, if set it will run without producing plots)
-    # --ref (if set it will analyze also the reference data, it is set
-    #        by default)
-    # --interface (custom interface file)
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_atm.yaml"
+    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_atm.yaml"
     outname: teleconnections
   teleconnections_oce:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 4
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_oce.yaml"
+    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_oce.yaml"
     outname: teleconnections
   tropical_rainfall:
     nworkers: 16

--- a/config/cli/config.aqua-analysis.ice.yaml
+++ b/config/cli/config.aqua-analysis.ice.yaml
@@ -28,9 +28,9 @@ job:
 
     # Default values, overriden from command line arguments
     catalog: null  # The catalog to use for the analysis
-    model: "IFS-NEMO"
-    exp: "historical-1990"
-    source: "lra-r100-monthly"
+    model: null
+    exp: null
+    source: null
 
     script_path_base: "${AQUA}/diagnostics"  # Base directory for the diagnostic scripts
 
@@ -65,7 +65,6 @@ diagnostics:
   global_biases:
     nworkers: 16
     script_path: "../src/aqua_diagnostics/global_biases/cli_global_biases.py"
-    extra: "--regrid F128"
     config: "${AQUA_CONFIG}/diagnostics/global_biases/cli/config_global_biases.yaml"
   timeseries_atm:
     script_path: "../src/aqua_diagnostics/timeseries/cli_timeseries.py"
@@ -85,7 +84,6 @@ diagnostics:
   radiation-biases:
     script_path: "../src/aqua_diagnostics/global_biases/cli_global_biases.py"
     nworkers: 8
-    extra: "--regrid F128"
     config: "${AQUA_CONFIG}/diagnostics/radiation/cli/config_radiation-biases.yaml"
     outname: radiation
   radiation-boxplots:
@@ -107,13 +105,11 @@ diagnostics:
     #        by default)
     # --interface (custom interface file)
     config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_atm.yaml"
-    extra: "--ref --regrid F128"
     outname: teleconnections
   teleconnections_oce:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 4
     config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_oce.yaml"
-    extra: "--ref --regrid F128"
     outname: teleconnections
   tropical_rainfall:
     nworkers: 16
@@ -127,12 +123,10 @@ diagnostics:
   ocean3d_drift:
     script_path: "ocean3d/cli/cli_ocean3d.py"
     nworkers: 8
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.drift.yaml"
   ocean3d_circulation:
     script_path: "ocean3d/cli/cli_ocean3d.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.circulation.yaml"
   seaice_volume:
     script_path: "seaice/cli/cli_seaice.py"
@@ -142,20 +136,16 @@ diagnostics:
     #               (default is False)
     # --config (seaice config file)
     # --regrid (regrid data to a different grid)
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Volume.yaml"
   seaice_thick:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Thickness.yaml"
   seaice_conc:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Concentration.yaml"
   seaice_extent:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Extent.yaml"

--- a/config/cli/config.aqua-analysis.oce.yaml
+++ b/config/cli/config.aqua-analysis.oce.yaml
@@ -99,17 +99,12 @@ diagnostics:
   teleconnections_atm:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 8
-    # Command line extra arguments for teleconnections:
-    # --dry, -d (dry run, if set it will run without producing plots)
-    # --ref (if set it will analyze also the reference data, it is set
-    #        by default)
-    # --interface (custom interface file)
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_atm.yaml"
+    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_atm.yaml"
     outname: teleconnections
   teleconnections_oce:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 4
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_oce.yaml"
+    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_oce.yaml"
     outname: teleconnections
   tropical_rainfall:
     nworkers: 16

--- a/config/cli/config.aqua-analysis.oce.yaml
+++ b/config/cli/config.aqua-analysis.oce.yaml
@@ -28,9 +28,9 @@ job:
 
     # Default values, overriden from command line arguments
     catalog: null  # The catalog to use for the analysis
-    model: "IFS-NEMO"
-    exp: "historical-1990"
-    source: "lra-r100-monthly"
+    model: null
+    exp: null
+    source: null
 
     script_path_base: "${AQUA}/diagnostics"  # Base directory for the diagnostic scripts
 
@@ -65,7 +65,6 @@ diagnostics:
   global_biases:
     nworkers: 16
     script_path: "../src/aqua_diagnostics/global_biases/cli_global_biases.py"
-    extra: "--regrid F128"
     config: "${AQUA_CONFIG}/diagnostics/global_biases/cli/config_global_biases.yaml"
   timeseries_atm:
     script_path: "../src/aqua_diagnostics/timeseries/cli_timeseries.py"
@@ -85,7 +84,6 @@ diagnostics:
   radiation-biases:
     script_path: "../src/aqua_diagnostics/global_biases/cli_global_biases.py"
     nworkers: 8
-    extra: "--regrid F128"
     config: "${AQUA_CONFIG}/diagnostics/radiation/cli/config_radiation-biases.yaml"
     outname: radiation
   radiation-boxplots:
@@ -107,13 +105,11 @@ diagnostics:
     #        by default)
     # --interface (custom interface file)
     config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_atm.yaml"
-    extra: "--ref --regrid F128"
     outname: teleconnections
   teleconnections_oce:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 4
     config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_oce.yaml"
-    extra: "--ref --regrid F128"
     outname: teleconnections
   tropical_rainfall:
     nworkers: 16
@@ -127,12 +123,10 @@ diagnostics:
   ocean3d_drift:
     script_path: "ocean3d/cli/cli_ocean3d.py"
     nworkers: 8
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.drift.yaml"
   ocean3d_circulation:
     script_path: "ocean3d/cli/cli_ocean3d.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.circulation.yaml"
   seaice_volume:
     script_path: "seaice/cli/cli_seaice.py"
@@ -142,20 +136,16 @@ diagnostics:
     #               (default is False)
     # --config (seaice config file)
     # --regrid (regrid data to a different grid)
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Volume.yaml"
   seaice_thick:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Thickness.yaml"
   seaice_conc:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Concentration.yaml"
   seaice_extent:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Extent.yaml"

--- a/config/cli_ecefast/config.aqua-analysis.atm.yaml
+++ b/config/cli_ecefast/config.aqua-analysis.atm.yaml
@@ -68,7 +68,6 @@ diagnostics:
   global_biases:
     nworkers: 16
     script_path: "../src/aqua_diagnostics/global_biases/cli_global_biases.py"
-    extra: "--regrid r200"
     config: "${AQUA_CONFIG}/diagnostics/global_biases/cli/config_global_biases.yaml"
   timeseries_atm:
     script_path: "../src/aqua_diagnostics/timeseries/cli_timeseries.py"
@@ -88,7 +87,6 @@ diagnostics:
   radiation-biases:
     script_path: "../src/aqua_diagnostics/global_biases/cli_global_biases.py"
     nworkers: 8
-    extra: "--regrid r200"
     config: "${AQUA_CONFIG}/diagnostics/radiation/cli/config_radiation-biases.yaml"
     outname: radiation
   radiation-boxplots:
@@ -128,12 +126,10 @@ diagnostics:
   ocean3d_drift:
     script_path: "ocean3d/cli/cli_ocean3d.py"
     nworkers: 8
-    extra: "--regrid=r200"
     config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.drift.yaml"
   ocean3d_circulation:
     script_path: "ocean3d/cli/cli_ocean3d.py"
     nworkers: 4
-    extra: "--regrid=r200"
     config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.circulation.yaml"
   seaice_volume:
     script_path: "seaice/cli/cli_seaice.py"
@@ -143,20 +139,16 @@ diagnostics:
     #               (default is False)
     # --config (seaice config file)
     # --regrid (regrid data to a different grid)
-    extra: "--regrid=r200"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Volume.yaml"
   seaice_thick:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r200"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Thickness.yaml"
   seaice_conc:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r200"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Concentration.yaml"
   seaice_extent:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r200"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Extent.yaml"

--- a/config/cli_ecefast/config.aqua-analysis.atm.yaml
+++ b/config/cli_ecefast/config.aqua-analysis.atm.yaml
@@ -102,17 +102,12 @@ diagnostics:
   teleconnections_atm:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 8
-    # Command line extra arguments for teleconnections:
-    # --dry, -d (dry run, if set it will run without producing plots)
-    # --ref (if set it will analyze also the reference data, it is set
-    #        by default)
-    # --interface (custom interface file)
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_atm.yaml"
+    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_atm.yaml"
     outname: teleconnections
   teleconnections_oce:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 4
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_oce.yaml"
+    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_oce.yaml"
     outname: teleconnections
   tropical_rainfall:
     nworkers: 16

--- a/config/cli_ecefast/config.aqua-analysis.ice.yaml
+++ b/config/cli_ecefast/config.aqua-analysis.ice.yaml
@@ -65,7 +65,6 @@ diagnostics:
   global_biases:
     nworkers: 16
     script_path: "../src/aqua_diagnostics/global_biases/cli_global_biases.py"
-    extra: "--regrid F128"
     config: "${AQUA_CONFIG}/diagnostics/global_biases/cli/config_global_biases.yaml"
   timeseries_atm:
     script_path: "../src/aqua_diagnostics/timeseries/cli_timeseries.py"
@@ -85,7 +84,6 @@ diagnostics:
   radiation-biases:
     script_path: "../src/aqua_diagnostics/global_biases/cli_global_biases.py"
     nworkers: 8
-    extra: "--regrid F128"
     config: "${AQUA_CONFIG}/diagnostics/radiation/cli/config_radiation-biases.yaml"
     outname: radiation
   radiation-boxplots:
@@ -107,18 +105,16 @@ diagnostics:
     #        by default)
     # --interface (custom interface file)
     config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_atm.yaml"
-    extra: "--ref --regrid F128"
     outname: teleconnections
   teleconnections_oce:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 4
     config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_oce.yaml"
-    extra: "--ref --regrid F128"
     outname: teleconnections
   tropical_rainfall:
     nworkers: 16
     config: "${AQUA_CONFIG}/diagnostics/tropical_rainfall/cli/cli_config_trop_rainfall.yml"
-    extra: "--regrid=r100 --freq=M --xmax=75 --bufferdir=${OUTPUT}/tropical_rainfall/"
+    extra: "--regrid=r200 --freq=M --xmax=75 --bufferdir=${OUTPUT}/tropical_rainfall/"
   ecmean:
     script_path: "../src/aqua_diagnostics/ecmean/cli_ecmean.py"
     nworkers: 4
@@ -127,12 +123,10 @@ diagnostics:
   ocean3d_drift:
     script_path: "ocean3d/cli/cli_ocean3d.py"
     nworkers: 8
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.drift.yaml"
   ocean3d_circulation:
     script_path: "ocean3d/cli/cli_ocean3d.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.circulation.yaml"
   seaice_volume:
     script_path: "seaice/cli/cli_seaice.py"
@@ -142,20 +136,16 @@ diagnostics:
     #               (default is False)
     # --config (seaice config file)
     # --regrid (regrid data to a different grid)
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Volume.yaml"
   seaice_thick:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Thickness.yaml"
   seaice_conc:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Concentration.yaml"
   seaice_extent:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r100"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Extent.yaml"

--- a/config/cli_ecefast/config.aqua-analysis.ice.yaml
+++ b/config/cli_ecefast/config.aqua-analysis.ice.yaml
@@ -99,17 +99,12 @@ diagnostics:
   teleconnections_atm:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 8
-    # Command line extra arguments for teleconnections:
-    # --dry, -d (dry run, if set it will run without producing plots)
-    # --ref (if set it will analyze also the reference data, it is set
-    #        by default)
-    # --interface (custom interface file)
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_atm.yaml"
+    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_atm.yaml"
     outname: teleconnections
   teleconnections_oce:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 4
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_oce.yaml"
+    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_oce.yaml"
     outname: teleconnections
   tropical_rainfall:
     nworkers: 16

--- a/config/cli_ecefast/config.aqua-analysis.oce.yaml
+++ b/config/cli_ecefast/config.aqua-analysis.oce.yaml
@@ -65,7 +65,6 @@ diagnostics:
   global_biases:
     nworkers: 16
     script_path: "../src/aqua_diagnostics/global_biases/cli_global_biases.py"
-    extra: "--regrid r200"
     config: "${AQUA_CONFIG}/diagnostics/global_biases/cli/config_global_biases.yaml"
   timeseries_atm:
     script_path: "../src/aqua_diagnostics/timeseries/cli_timeseries.py"
@@ -85,7 +84,6 @@ diagnostics:
   radiation-biases:
     script_path: "../src/aqua_diagnostics/global_biases/cli_global_biases.py"
     nworkers: 8
-    extra: "--regrid r200"
     config: "${AQUA_CONFIG}/diagnostics/radiation/cli/config_radiation-biases.yaml"
     outname: radiation
   radiation-boxplots:
@@ -125,12 +123,10 @@ diagnostics:
   ocean3d_drift:
     script_path: "ocean3d/cli/cli_ocean3d.py"
     nworkers: 8
-    extra: "--regrid=r200"
     config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.drift.yaml"
   ocean3d_circulation:
     script_path: "ocean3d/cli/cli_ocean3d.py"
     nworkers: 4
-    extra: "--regrid=r200"
     config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.circulation.yaml"
   seaice_volume:
     script_path: "seaice/cli/cli_seaice.py"
@@ -140,20 +136,16 @@ diagnostics:
     #               (default is False)
     # --config (seaice config file)
     # --regrid (regrid data to a different grid)
-    extra: "--regrid=r200"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Volume.yaml"
   seaice_thick:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r200"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Thickness.yaml"
   seaice_conc:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r200"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Concentration.yaml"
   seaice_extent:
     script_path: "seaice/cli/cli_seaice.py"
     nworkers: 4
-    extra: "--regrid=r200"
     config: "${AQUA_CONFIG}/diagnostics/seaice/cli/config_Extent.yaml"

--- a/config/cli_ecefast/config.aqua-analysis.oce.yaml
+++ b/config/cli_ecefast/config.aqua-analysis.oce.yaml
@@ -99,17 +99,12 @@ diagnostics:
   teleconnections_atm:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 8
-    # Command line extra arguments for teleconnections:
-    # --dry, -d (dry run, if set it will run without producing plots)
-    # --ref (if set it will analyze also the reference data, it is set
-    #        by default)
-    # --interface (custom interface file)
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_atm.yaml"
+    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_atm.yaml"
     outname: teleconnections
   teleconnections_oce:
     script_path: "../src/aqua_diagnostics/teleconnections/cli_teleconnections.py"
     nworkers: 4
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/cli_config_oce.yaml"
+    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_oce.yaml"
     outname: teleconnections
   tropical_rainfall:
     nworkers: 16

--- a/jobs/aqua_analysis.tmpl
+++ b/jobs/aqua_analysis.tmpl
@@ -17,7 +17,10 @@ set -eo
 catalog=<catalog> # available are hpc2020, epochal
 model=<model> # available are EC-EARTH4, ECE-FAST
 exp=<experiment>
+regrid=<regrid> # we suggest 'r100' for EC-EARTH4 and 'r200' for ECE-FAST. False to deactivate regridding
 
+# This for HPC2020, if you have a conda environment, you should comment this line
+# and load the environment in the next line
 module load tykky
 tykky activate aqua
 
@@ -41,10 +44,10 @@ else
 fi
 
 # We use three different scripts because they all use different sources
-python aqua-analysis.py -l debug -c $catalog -m $model -e $exp -s monthly-atm -d $OUTDIR -p --config $configatm
+python aqua-analysis.py -l debug -c $catalog -m $model -e $exp -s monthly-atm -d $OUTDIR -p --config $configatm --regrid $regrid
 if [ "$amip" = false ]; then
-    python aqua-analysis.py -l debug -c $catalog -m $model -e $exp -s monthly-oce -d $OUTDIR -p --config $configoce
-    python aqua-analysis.py -l debug -c $catalog -m $model -e $exp -s monthly-ice -d $OUTDIR -p --config $configice
+    python aqua-analysis.py -l debug -c $catalog -m $model -e $exp -s monthly-oce -d $OUTDIR -p --config $configoce --regrid $regrid
+    python aqua-analysis.py -l debug -c $catalog -m $model -e $exp -s monthly-ice -d $OUTDIR -p --config $configice --regrid $regrid
 fi
 
 #cd /ec/res4/hpcperm/ccjh/AQUA/cli/aqua-web


### PR DESCRIPTION
Introducing in the .job template the regrid option.
Removing the hardcoded regrid option from the config files