### PR TITLE
Updates for v0.21.0 

### DIFF
--- a/catalog-generator/catalog-generator.py
+++ b/catalog-generator/catalog-generator.py
@@ -13,8 +13,9 @@ import jinja2
 from filelock import FileLock
 
 from aqua import Reader, inspect_catalog
-from aqua.util import ConfigPath, load_yaml, dump_yaml, get_arg
-from aqua.logger import log_configure
+from aqua.core.configurer import ConfigPath
+from aqua.core.util import load_yaml, dump_yaml, get_arg
+from aqua.core.logger import log_configure
 
 
 def parse_arguments(arguments):

--- a/catalog-generator/ec-earth.j2
+++ b/catalog-generator/ec-earth.j2
@@ -9,7 +9,7 @@ sources:
     driver: netcdf
     metadata:
       time_coder: 's'
-      source_grid_name: {{ ifs_grid }}
+      source_grid_name: {{ ifs_grid }}-ece
       fixer_name: {{ ifs_fixer }}
     args:
       urlpath:

--- a/catalog-generator/ec-earth.j2
+++ b/catalog-generator/ec-earth.j2
@@ -11,6 +11,7 @@ sources:
       time_coder: 's'
       source_grid_name: {{ ifs_grid }}-ece
       fixer_name: {{ ifs_fixer }}
+      filter_key: year
     args:
       urlpath:
           - {{ path }}/{{ exp }}/output/oifs/{{ exp }}_atm_cmip6_{{ exp_freq }}*.nc
@@ -28,6 +29,7 @@ sources:
       time_coder: 's'
       source_grid_name: {{ nemo_grid }}-ece
       fixer_name: {{ nemo_fixer }}
+      filter_key: year
     args:
       urlpath: {{ path }}/{{ exp }}/output/nemo/{{ exp }}_oce_{{ exp_freq }}_T_*.nc
       chunks:
@@ -42,6 +44,7 @@ sources:
       time_coder: 's'
       source_grid_name: {{ nemo_grid }}-ece-ice
       fixer_name: {{ ice_fixer }}
+      filter_key: year
     args:
       urlpath: {{ path }}/{{ exp }}/output/nemo/{{ exp }}_ice_{{ exp_freq }}_*.nc
       chunks:

--- a/catalogs/ece4-tuning/catalog/ECE-FAST/LC21.yaml
+++ b/catalogs/ece4-tuning/catalog/ECE-FAST/LC21.yaml
@@ -1,0 +1,63 @@
+plugins:
+  source:
+    - module: intake_xarray
+
+sources:
+
+  monthly-atm:
+    description: IFS 2D atmospheric data on tl63 grid.
+    driver: netcdf
+    metadata:
+      time_coder: 's'
+      source_grid_name: tl63-ece
+      fixer_name: ec-earth4-ifs
+    args:
+      urlpath:
+          - /ec/res4/scratch/ccpd/ece4/LC21/output/oifs/LC21_atm_cmip6_1m*.nc
+          - /ec/res4/scratch/ccpd/ece4/LC21/output/oifs/LC21_atm_cmip6_pl_1m*.nc
+      chunks:
+        time: 1
+      xarray_kwargs:
+        decode_times: True
+
+  monthly-oce:
+    description: NEMO ocean T output
+    driver: netcdf
+    metadata:
+      time_coder: 's'
+      source_grid_name: PALEORCA2-pd-ece
+      fixer_name: ec-earth4-nemo
+    args:
+      urlpath: /ec/res4/scratch/ccpd/ece4/LC21/output/nemo/LC21_oce_1m_T_*.nc
+      chunks:
+        time_counter: 1
+      xarray_kwargs:
+        decode_times: True
+
+  monthly-ice:
+    description: NEMO ice output
+    driver: netcdf
+    metadata:
+      time_coder: 's'
+      source_grid_name: PALEORCA2-pd-ece-ice
+      fixer_name: ec-earth4-nemo-ice
+    args:
+      urlpath: /ec/res4/scratch/ccpd/ece4/LC21/output/nemo/LC21_ice_1m_*.nc
+      chunks:
+        time_counter: 1
+      xarray_kwargs:
+        decode_times: True
+
+  # this is here only because of the OutputSaver bug #1685
+  lra-r100-monthly:
+    driver: netcdf
+    description: LRA data monthly at r100
+    args:
+      urlpath: '/dummy/*_r100_monthly_*.nc'
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+        combine: by_coords
+    metadata:
+      time_coder: 's'
+      source_grid_name: lon-lat

--- a/catalogs/ece4-tuning/catalog/ECE-FAST/T020.yaml
+++ b/catalogs/ece4-tuning/catalog/ECE-FAST/T020.yaml
@@ -198,6 +198,8 @@ sources:
       urlpath: 
         /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/T020/{{realization}}/radiation-surface/netcdf/radiation_surface.annual_climatology.ece4-tuning.ECE-FAST.T020.{{realization}}.*.nc
       chunks: {}
+      xarray_kwargs:
+        decode_times: true
     metadata:
       source_grid_name: false
     parameters:
@@ -215,6 +217,8 @@ sources:
       urlpath: 
         /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/T020/{{realization}}/radiation-toa/netcdf/radiation_toa.seasonal_climatology.ece4-tuning.ECE-FAST.T020.{{realization}}.*.nc
       chunks: {}
+      xarray_kwargs:
+        decode_times: true
     metadata:
       source_grid_name: false
     parameters:
@@ -232,6 +236,8 @@ sources:
       urlpath: 
         /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/T020/{{realization}}/radiation-surface/netcdf/radiation_surface.seasonal_climatology.ece4-tuning.ECE-FAST.T020.{{realization}}.*.nc
       chunks: {}
+      xarray_kwargs:
+        decode_times: true
     metadata:
       source_grid_name: false
     parameters:

--- a/catalogs/ece4-tuning/catalog/ECE-FAST/T020.yaml
+++ b/catalogs/ece4-tuning/catalog/ECE-FAST/T020.yaml
@@ -9,12 +9,12 @@ sources:
     driver: netcdf
     metadata:
       time_coder: s
-      source_grid_name: tl63
+      source_grid_name: tl63-ece
       fixer_name: ec-earth4-ifs
     args:
       urlpath:
-      - /ec/res4/scratch/ecme3497/ece4/pic1/output/oifs/pic1_atm_cmip6_1m*.nc
-      - /ec/res4/scratch/ecme3497/ece4/pic1/output/oifs/pic1_atm_cmip6_pl_1m*.nc
+      - /ec/res4/scratch/ccpd/ece4/T020/output/oifs/T020_atm_cmip6_1m*.nc
+      - /ec/res4/scratch/ccpd/ece4/T020/output/oifs/T020_atm_cmip6_pl_1m*.nc
       chunks:
         time: 1
       xarray_kwargs:
@@ -28,8 +28,7 @@ sources:
       source_grid_name: ORCA2-ece
       fixer_name: ec-earth4-nemo
     args:
-      urlpath: 
-        /ec/res4/scratch/ecme3497/ece4/pic1/output/nemo/pic1_oce_1m_T_*.nc
+      urlpath: /ec/res4/scratch/ccpd/ece4/T020/output/nemo/T020_oce_1m_T_*.nc
       chunks:
         time_counter: 1
       xarray_kwargs:
@@ -43,7 +42,7 @@ sources:
       source_grid_name: ORCA2-ece-ice
       fixer_name: ec-earth4-nemo-ice
     args:
-      urlpath: /ec/res4/scratch/ecme3497/ece4/pic1/output/nemo/pic1_ice_1m_*.nc
+      urlpath: /ec/res4/scratch/ccpd/ece4/T020/output/nemo/T020_ice_1m_*.nc
       chunks:
         time_counter: 1
       xarray_kwargs:
@@ -68,26 +67,7 @@ sources:
       annual_climatology
     args:
       urlpath: 
-        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/atmosphere2d/netcdf/atmosphere2d.annual_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
-      chunks: {}
-      xarray_kwargs:
-        decode_times: true
-    metadata:
-      source_grid_name: false
-    parameters:
-      realization:
-        description: Parameter realization
-        default: r1
-        type: str
-        allowed:
-        - r1
-  aqua-atmosphere2d-seasonal_climatology:
-    driver: netcdf
-    description: AQUA diagnostic atmosphere2d data for product 
-      seasonal_climatology
-    args:
-      urlpath: 
-        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/atmosphere2d/netcdf/atmosphere2d.seasonal_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/T020/{{realization}}/atmosphere2d/netcdf/atmosphere2d.annual_climatology.ece4-tuning.ECE-FAST.T020.{{realization}}.*.nc
       chunks: {}
       xarray_kwargs:
         decode_times: true
@@ -106,7 +86,7 @@ sources:
       annual_climatology
     args:
       urlpath: 
-        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/atmosphere3d/netcdf/atmosphere3d.annual_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/T020/{{realization}}/atmosphere3d/netcdf/atmosphere3d.annual_climatology.ece4-tuning.ECE-FAST.T020.{{realization}}.*.nc
       chunks: {}
       xarray_kwargs:
         decode_times: true
@@ -125,7 +105,7 @@ sources:
       seasonal_climatology
     args:
       urlpath: 
-        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/atmosphere3d/netcdf/atmosphere3d.seasonal_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/T020/{{realization}}/atmosphere3d/netcdf/atmosphere3d.seasonal_climatology.ece4-tuning.ECE-FAST.T020.{{realization}}.*.nc
       chunks: {}
       xarray_kwargs:
         decode_times: true
@@ -138,32 +118,66 @@ sources:
         type: str
         allowed:
         - r1
+  aqua-atmosphere2d-seasonal_climatology:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere2d data for product 
+      seasonal_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/T020/{{realization}}/atmosphere2d/netcdf/atmosphere2d.seasonal_climatology.ece4-tuning.ECE-FAST.T020.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-atmosphere2d-timeseries:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere2d data for product timeseries
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/T020/{{realization}}/atmosphere2d/netcdf/atmosphere2d.timeseries.ece4-tuning.ECE-FAST.T020.{{realization}}.*.{{freq}}.{{region}}.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      freq:
+        description: Parameter freq
+        default: monthly
+        type: str
+        allowed:
+        - monthly
+        - annual
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+      region:
+        description: Parameter region
+        default: global
+        type: str
+        allowed:
+        - global
+        - North Midlatitudes
+        - South Midlatitudes
+        - Europe
   aqua-radiation_toa-annual_climatology:
     driver: netcdf
     description: AQUA diagnostic radiation_toa data for product 
       annual_climatology
     args:
       urlpath: 
-        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/radiation-toa/netcdf/radiation_toa.annual_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
-      chunks: {}
-      xarray_kwargs:
-        decode_times: true
-    metadata:
-      source_grid_name: false
-    parameters:
-      realization:
-        description: Parameter realization
-        default: r1
-        type: str
-        allowed:
-        - r1
-  aqua-radiation_toa-seasonal_climatology:
-    driver: netcdf
-    description: AQUA diagnostic radiation_toa data for product 
-      seasonal_climatology
-    args:
-      urlpath: 
-        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/radiation-toa/netcdf/radiation_toa.seasonal_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/T020/{{realization}}/radiation-toa/netcdf/radiation_toa.annual_climatology.ece4-tuning.ECE-FAST.T020.{{realization}}.*.nc
       chunks: {}
       xarray_kwargs:
         decode_times: true
@@ -182,10 +196,25 @@ sources:
       annual_climatology
     args:
       urlpath: 
-        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/radiation-surface/netcdf/radiation_surface.annual_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/T020/{{realization}}/radiation-surface/netcdf/radiation_surface.annual_climatology.ece4-tuning.ECE-FAST.T020.{{realization}}.*.nc
       chunks: {}
-      xarray_kwargs:
-        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-radiation_toa-seasonal_climatology:
+    driver: netcdf
+    description: AQUA diagnostic radiation_toa data for product 
+      seasonal_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/T020/{{realization}}/radiation-toa/netcdf/radiation_toa.seasonal_climatology.ece4-tuning.ECE-FAST.T020.{{realization}}.*.nc
+      chunks: {}
     metadata:
       source_grid_name: false
     parameters:
@@ -201,10 +230,8 @@ sources:
       seasonal_climatology
     args:
       urlpath: 
-        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/radiation-surface/netcdf/radiation_surface.seasonal_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/T020/{{realization}}/radiation-surface/netcdf/radiation_surface.seasonal_climatology.ece4-tuning.ECE-FAST.T020.{{realization}}.*.nc
       chunks: {}
-      xarray_kwargs:
-        decode_times: true
     metadata:
       source_grid_name: false
     parameters:

--- a/catalogs/ece4-tuning/catalog/ECE-FAST/main.yaml
+++ b/catalogs/ece4-tuning/catalog/ECE-FAST/main.yaml
@@ -69,3 +69,13 @@ sources:
     driver: yaml_file_cat
     args:
       path: '{{CATALOG_DIR}}/FWD4.yaml'
+  pic1:
+    description: EC-EARTH4 test preindustrial
+    driver: yaml_file_cat
+    args:
+      path: '{{CATALOG_DIR}}/pic1.yaml'
+  pic2:
+    description: EC-EARTH4 test preindustrial
+    driver: yaml_file_cat
+    args:
+      path: '{{CATALOG_DIR}}/pic2.yaml'

--- a/catalogs/ece4-tuning/catalog/ECE-FAST/main.yaml
+++ b/catalogs/ece4-tuning/catalog/ECE-FAST/main.yaml
@@ -69,13 +69,18 @@ sources:
     driver: yaml_file_cat
     args:
       path: '{{CATALOG_DIR}}/FWD4.yaml'
-  pic1:
-    description: EC-EARTH4 test preindustrial
-    driver: yaml_file_cat
-    args:
-      path: '{{CATALOG_DIR}}/pic1.yaml'
   pic2:
-    description: EC-EARTH4 test preindustrial
+    description: EC-EARTH4 overshoot 2262 test
     driver: yaml_file_cat
     args:
       path: '{{CATALOG_DIR}}/pic2.yaml'
+  T020:
+    description: EC-EARTH4 110 year test 
+    driver: yaml_file_cat
+    args:
+      path: '{{CATALOG_DIR}}/T020.yaml'
+  LC21:
+    description: EC-EARTH4 PALEORCA test
+    driver: yaml_file_cat
+    args:
+      path: '{{CATALOG_DIR}}/LC21.yaml'

--- a/catalogs/ece4-tuning/catalog/ECE-FAST/pic1.yaml
+++ b/catalogs/ece4-tuning/catalog/ECE-FAST/pic1.yaml
@@ -1,0 +1,216 @@
+plugins:
+  source:
+  - module: intake_xarray
+
+sources:
+
+  monthly-atm:
+    description: IFS 2D atmospheric data on tl63 grid.
+    driver: netcdf
+    metadata:
+      time_coder: s
+      source_grid_name: tl63
+      fixer_name: ec-earth4-ifs
+    args:
+      urlpath:
+      - /ec/res4/scratch/ecme3497/ece4/pic1/output/oifs/pic1_atm_cmip6_1m*.nc
+      - /ec/res4/scratch/ecme3497/ece4/pic1/output/oifs/pic1_atm_cmip6_pl_1m*.nc
+      chunks:
+        time: 1
+      xarray_kwargs:
+        decode_times: true
+
+  monthly-oce:
+    description: NEMO ocean T output
+    driver: netcdf
+    metadata:
+      time_coder: s
+      source_grid_name: ORCA2-ece
+      fixer_name: ec-earth4-nemo
+    args:
+      urlpath: 
+        /ec/res4/scratch/ecme3497/ece4/pic1/output/nemo/pic1_oce_1m_T_*.nc
+      chunks:
+        time_counter: 1
+      xarray_kwargs:
+        decode_times: true
+
+  monthly-ice:
+    description: NEMO ice output
+    driver: netcdf
+    metadata:
+      time_coder: s
+      source_grid_name: ORCA2-ece-ice
+      fixer_name: ec-earth4-nemo-ice
+    args:
+      urlpath: /ec/res4/scratch/ecme3497/ece4/pic1/output/nemo/pic1_ice_1m_*.nc
+      chunks:
+        time_counter: 1
+      xarray_kwargs:
+        decode_times: true
+
+  # this is here only because of the OutputSaver bug #1685
+  lra-r100-monthly:
+    driver: netcdf
+    description: LRA data monthly at r100
+    args:
+      urlpath: /dummy/*_r100_monthly_*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+        combine: by_coords
+    metadata:
+      time_coder: s
+      source_grid_name: lon-lat
+  aqua-atmosphere2d-annual_climatology:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere2d data for product 
+      annual_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/atmosphere2d/netcdf/atmosphere2d.annual_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-atmosphere2d-seasonal_climatology:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere2d data for product 
+      seasonal_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/atmosphere2d/netcdf/atmosphere2d.seasonal_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-atmosphere3d-annual_climatology:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere3d data for product 
+      annual_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/atmosphere3d/netcdf/atmosphere3d.annual_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-atmosphere3d-seasonal_climatology:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere3d data for product 
+      seasonal_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/atmosphere3d/netcdf/atmosphere3d.seasonal_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-radiation_toa-annual_climatology:
+    driver: netcdf
+    description: AQUA diagnostic radiation_toa data for product 
+      annual_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/radiation-toa/netcdf/radiation_toa.annual_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-radiation_toa-seasonal_climatology:
+    driver: netcdf
+    description: AQUA diagnostic radiation_toa data for product 
+      seasonal_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/radiation-toa/netcdf/radiation_toa.seasonal_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-radiation_surface-annual_climatology:
+    driver: netcdf
+    description: AQUA diagnostic radiation_surface data for product 
+      annual_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/radiation-surface/netcdf/radiation_surface.annual_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-radiation_surface-seasonal_climatology:
+    driver: netcdf
+    description: AQUA diagnostic radiation_surface data for product 
+      seasonal_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic1/{{realization}}/radiation-surface/netcdf/radiation_surface.seasonal_climatology.ece4-tuning.ECE-FAST.pic1.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1

--- a/catalogs/ece4-tuning/catalog/ECE-FAST/pic2.yaml
+++ b/catalogs/ece4-tuning/catalog/ECE-FAST/pic2.yaml
@@ -1,6 +1,6 @@
 plugins:
   source:
-    - module: intake_xarray
+  - module: intake_xarray
 
 sources:
 
@@ -8,37 +8,39 @@ sources:
     description: IFS 2D atmospheric data on tl63 grid.
     driver: netcdf
     metadata:
-      time_coder: 's'
-      source_grid_name: tl63
+      time_coder: s
+      source_grid_name: tl63-ece
       fixer_name: ec-earth4-ifs
     args:
       urlpath:
-          - /ec/res4/scratch/ecme3497/ece4/pic2/output/oifs/pic2_atm_cmip6_1m*.nc
-          - /ec/res4/scratch/ecme3497/ece4/pic2/output/oifs/pic2_atm_cmip6_pl_1m*.nc
+      - /ec/res4/scratch/ecme3497/ece4/pic2/output/oifs/pic2_atm_cmip6_1m*.nc
+      - /ec/res4/scratch/ecme3497/ece4/pic2/output/oifs/pic2_atm_cmip6_pl_1m*.nc
       chunks:
         time: 1
       xarray_kwargs:
-        decode_times: True
+        decode_times: true
+        #use_cftime: true
 
   monthly-oce:
     description: NEMO ocean T output
     driver: netcdf
     metadata:
-      time_coder: 's'
+      time_coder: s
       source_grid_name: ORCA2-ece
       fixer_name: ec-earth4-nemo
     args:
-      urlpath: /ec/res4/scratch/ecme3497/ece4/pic2/output/nemo/pic2_oce_1m_T_*.nc
+      urlpath: 
+        /ec/res4/scratch/ecme3497/ece4/pic2/output/nemo/pic2_oce_1m_T_*.nc
       chunks:
         time_counter: 1
       xarray_kwargs:
-        decode_times: True
+        decode_times: true
 
   monthly-ice:
     description: NEMO ice output
     driver: netcdf
     metadata:
-      time_coder: 's'
+      time_coder: s
       source_grid_name: ORCA2-ece-ice
       fixer_name: ec-earth4-nemo-ice
     args:
@@ -46,18 +48,236 @@ sources:
       chunks:
         time_counter: 1
       xarray_kwargs:
-        decode_times: True
+        decode_times: true
 
   # this is here only because of the OutputSaver bug #1685
   lra-r100-monthly:
     driver: netcdf
     description: LRA data monthly at r100
     args:
-      urlpath: '/dummy/*_r100_monthly_*.nc'
+      urlpath: /dummy/*_r100_monthly_*.nc
       chunks: {}
       xarray_kwargs:
         decode_times: true
         combine: by_coords
     metadata:
-      time_coder: 's'
+      time_coder: s
       source_grid_name: lon-lat
+  aqua-atmosphere2d-annual_climatology:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere2d data for product 
+      annual_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic2/{{realization}}/atmosphere2d/netcdf/atmosphere2d.annual_climatology.ece4-tuning.ECE-FAST.pic2.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-atmosphere2d-seasonal_climatology:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere2d data for product 
+      seasonal_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic2/{{realization}}/atmosphere2d/netcdf/atmosphere2d.seasonal_climatology.ece4-tuning.ECE-FAST.pic2.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-atmosphere3d-annual_climatology:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere3d data for product 
+      annual_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic2/{{realization}}/atmosphere3d/netcdf/atmosphere3d.annual_climatology.ece4-tuning.ECE-FAST.pic2.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-atmosphere3d-seasonal_climatology:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere3d data for product 
+      seasonal_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic2/{{realization}}/atmosphere3d/netcdf/atmosphere3d.seasonal_climatology.ece4-tuning.ECE-FAST.pic2.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-radiation_toa-annual_climatology:
+    driver: netcdf
+    description: AQUA diagnostic radiation_toa data for product 
+      annual_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic2/{{realization}}/radiation-toa/netcdf/radiation_toa.annual_climatology.ece4-tuning.ECE-FAST.pic2.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-radiation_surface-annual_climatology:
+    driver: netcdf
+    description: AQUA diagnostic radiation_surface data for product 
+      annual_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic2/{{realization}}/radiation-surface/netcdf/radiation_surface.annual_climatology.ece4-tuning.ECE-FAST.pic2.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-radiation_toa-seasonal_climatology:
+    driver: netcdf
+    description: AQUA diagnostic radiation_toa data for product 
+      seasonal_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic2/{{realization}}/radiation-toa/netcdf/radiation_toa.seasonal_climatology.ece4-tuning.ECE-FAST.pic2.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-radiation_surface-seasonal_climatology:
+    driver: netcdf
+    description: AQUA diagnostic radiation_surface data for product 
+      seasonal_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic2/{{realization}}/radiation-surface/netcdf/radiation_surface.seasonal_climatology.ece4-tuning.ECE-FAST.pic2.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-ocean2d-annual_climatology:
+    driver: netcdf
+    description: AQUA diagnostic ocean2d data for product annual_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic2/{{realization}}/ocean2d/netcdf/ocean2d.annual_climatology.ece4-tuning.ECE-FAST.pic2.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-ocean2d-seasonal_climatology:
+    driver: netcdf
+    description: AQUA diagnostic ocean2d data for product seasonal_climatology
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic2/{{realization}}/ocean2d/netcdf/ocean2d.seasonal_climatology.ece4-tuning.ECE-FAST.pic2.{{realization}}.*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+  aqua-atmosphere2d-seasonalcycles:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere2d data for product seasonalcycles
+    args:
+      urlpath: 
+        /ec/res4/scratch/ccpd/aqua-analysis/ece4-tuning/ECE-FAST/pic2/{{realization}}/atmosphere2d/netcdf/atmosphere2d.seasonalcycles.ece4-tuning.ECE-FAST.pic2.{{realization}}.*.{{freq}}.{{region}}.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      freq:
+        description: Parameter freq
+        default: monthly
+        type: str
+        allowed:
+        - monthly
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+      region:
+        description: Parameter region
+        default: global
+        type: str
+        allowed:
+        - global

--- a/catalogs/ece4-tuning/catalog/ECE-FAST/pic2.yaml
+++ b/catalogs/ece4-tuning/catalog/ECE-FAST/pic2.yaml
@@ -1,0 +1,63 @@
+plugins:
+  source:
+    - module: intake_xarray
+
+sources:
+
+  monthly-atm:
+    description: IFS 2D atmospheric data on tl63 grid.
+    driver: netcdf
+    metadata:
+      time_coder: 's'
+      source_grid_name: tl63
+      fixer_name: ec-earth4-ifs
+    args:
+      urlpath:
+          - /ec/res4/scratch/ecme3497/ece4/pic2/output/oifs/pic2_atm_cmip6_1m*.nc
+          - /ec/res4/scratch/ecme3497/ece4/pic2/output/oifs/pic2_atm_cmip6_pl_1m*.nc
+      chunks:
+        time: 1
+      xarray_kwargs:
+        decode_times: True
+
+  monthly-oce:
+    description: NEMO ocean T output
+    driver: netcdf
+    metadata:
+      time_coder: 's'
+      source_grid_name: ORCA2-ece
+      fixer_name: ec-earth4-nemo
+    args:
+      urlpath: /ec/res4/scratch/ecme3497/ece4/pic2/output/nemo/pic2_oce_1m_T_*.nc
+      chunks:
+        time_counter: 1
+      xarray_kwargs:
+        decode_times: True
+
+  monthly-ice:
+    description: NEMO ice output
+    driver: netcdf
+    metadata:
+      time_coder: 's'
+      source_grid_name: ORCA2-ece-ice
+      fixer_name: ec-earth4-nemo-ice
+    args:
+      urlpath: /ec/res4/scratch/ecme3497/ece4/pic2/output/nemo/pic2_ice_1m_*.nc
+      chunks:
+        time_counter: 1
+      xarray_kwargs:
+        decode_times: True
+
+  # this is here only because of the OutputSaver bug #1685
+  lra-r100-monthly:
+    driver: netcdf
+    description: LRA data monthly at r100
+    args:
+      urlpath: '/dummy/*_r100_monthly_*.nc'
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+        combine: by_coords
+    metadata:
+      time_coder: 's'
+      source_grid_name: lon-lat

--- a/config/cli_ecefast/config.aqua-analysis.atm.yaml
+++ b/config/cli_ecefast/config.aqua-analysis.atm.yaml
@@ -4,27 +4,26 @@
 # the config directory (i.e. .aqua/diagnostics) and the output directory respectively
 
 job:
-    # The max_threads variable serves as a mechanism to control the maximum number of threads
-    # i.e. diagnostic scripts that can run concurrently.
-    # - If max_threads is set to 0 or a negative value: There is no limit on the number of threads,
+    # The max_threads variable serves as a mechanism to control the maximum number of diagnostics being run concurrently
+    # - If max_threads is set to 0 or a negative value: There is no limit on the number of parallel diagnostics,
     #                                                   and all processes run in parallel without waiting. 
     #                                                   This is suitable for situations where you want to utilize
     #                                                   the maximum available resources without any restrictions.
-    # - If max_threads is set to a positive value: It limits the number of concurrent threads to the specified value. 
-    #                                              After launching the designated number of threads, the script waits
-    #                                              for these threads to complete before launching additional ones. 
-    #                                              This is useful when you are working on a system with limitations
-    #                                              on the number of concurrent threads, like a login node.
+    # - If max_threads is set to a positive value: It limits the number of concurrent processes to the specified value. 
+    #                                              After launching the designated number of diagnostics, the script waits
+    #                                              for these to complete before launching additional ones. 
+    #                                              This is useful when you are working on a system with limited
+    #                                              resources, such as a login node
 
     max_threads: 0  # Set to the desired maximum number of threads, or leave it as 0 for no limit
     loglevel: "WARNING" # DEBUG, IN FO, WARNING, ERROR, CRITICAL
 
     # Run a check analysis to test the configuration and the presence of needed data
     # This also rebuild the area files, to avoid error with corrupted files
-    run_checker: True
+    run_checker: true
     
     # Default output directory for the analysis. Can be overridden by the command line arguments
-    outputdir: "${AQUA}/cli/aqua-analysis/output" 
+    outputdir: "./output"
 
     # Default values, overriden from command line arguments
     catalog: null  # The catalog to use for the analysis
@@ -32,6 +31,8 @@ job:
     exp: "historical-1990"
     source: "lra-r100-monthly"
     regrid: null
+    startdate: null
+    enddate: null
 
     script_path_base: "${AQUA}/src/aqua_diagnostics"  # Base directory for the diagnostic scripts
 
@@ -39,12 +40,29 @@ cluster:  # options for dask cluster (this works well on lumi)
     workers: 32
     threads: 1  # per worker
     memory_limit: 7GiB  # per worker
+    connect_timeout: 120  # seconds to wait for client to connect to the cluster
+    # ftp_timeout: 60  # timeout in seconds for ftp connections. Will not be set if omitted.
 
-diagnostics:
+# List of available CLI tools (diagnostics)
+cli:
+  biases: "global_biases/cli_global_biases.py"
+  boxplots: "boxplots/cli_boxplots.py"
+  drift: "ocean_drift/cli_ocean_drift.py"
+  ecmean: "ecmean/cli_ecmean.py"
+  enso: "teleconnections/cli_teleconnections.py"
+  gregory: "timeseries/cli_timeseries.py"
+  lat_lon_profiles: "lat_lon_profiles/cli_lat_lon_profiles.py"
+  nao: "teleconnections/cli_teleconnections.py"
+  seaice: "seaice/cli_seaice.py"
+  seasonal_cycles: "timeseries/cli_timeseries.py"  # not used
+  stratification: "ocean_stratification/cli_ocean_stratification.py"
+  timeseries: "timeseries/cli_timeseries.py"
+  trends: "ocean_trends/cli_ocean_trends.py"
+  tropical_rainfall: "../../diagnostics/tropical_rainfall/cli/cli_tropical_rainfall.py"
 
-  run: ["global_biases", "timeseries_atm",
-        "radiation-boxplots", "radiation-timeseries", "radiation-biases",
-        "ecmean"]
+run: 
+    - ["teleconnections", "climate_metrics", "atmosphere2d", "atmosphere3d"] # very fast ones first, a few min
+    - [ "radiation-surface", "radiation-toa"]
 
   # List of diagnostics
 
@@ -57,71 +75,81 @@ diagnostics:
   #    script_path: the location of the script to run the diagnostic.
   #                 Default script_path is "$script_path_base/$diagnostic/cli/cli_${diagnostic}.py"
   #    nocluster: boolean, if set to true, the diagnostic will not use the global dask cluster. Default is false (needed for ECmean)
+diagnostics:
+  atmosphere2d: 
+    biases: 
+      config: ["${AQUA_CONFIG}/diagnostics/atmosphere2d/config-atmosphere2d-berkeley.yaml", 
+               "${AQUA_CONFIG}/diagnostics/atmosphere2d/config-atmosphere2d-era5.yaml"]
+    timeseries:
+      config: ["${AQUA_CONFIG}/diagnostics/atmosphere2d/config-atmosphere2d-berkeley.yaml",
+               "${AQUA_CONFIG}/diagnostics/atmosphere2d/config-atmosphere2d-era5.yaml"]
+    lat_lon_profiles:
+      config: "${AQUA_CONFIG}/diagnostics/atmosphere2d/config-atmosphere2d-berkeley.yaml"
 
-  global_biases:
-    nworkers: 16
-    script_path: "global_biases/cli_global_biases.py"
-    config: "${AQUA_CONFIG}/diagnostics/global_biases/config_global_biases.yaml"
-  timeseries_atm:
-    script_path: "timeseries/cli_timeseries.py"
-    config: "${AQUA_CONFIG}/diagnostics/timeseries/config_timeseries_atm.yaml"
-    nworkers: 16
-    outname: timeseries
-  timeseries_oce:
-    script_path: "timeseries/cli_timeseries.py"
-    config: "${AQUA_CONFIG}/diagnostics/timeseries/config_timeseries_oce.yaml"
-    nworkers: 8
-    outname: timeseries
-  seasonal_cycles:
-    script_path: "timeseries/cli_timeseries.py"
-    nworkers: 16
-    config: "${AQUA_CONFIG}/diagnostics/timeseries/config_seasonalcycles_atm.yaml"
-    outname: timeseries
-  radiation-biases:
-    script_path: "global_biases/cli_global_biases.py"
-    nworkers: 8
-    config: "${AQUA_CONFIG}/diagnostics/radiation/config_radiation-biases.yaml"
-    outname: radiation
-  radiation-boxplots:
-    script_path: "boxplots/cli_boxplots.py"
-    nworkers: 8
-    config: "${AQUA_CONFIG}/diagnostics/radiation/config_radiation-boxplots.yaml"
-    outname: radiation
-  radiation-timeseries:
-    script_path: "timeseries/cli_timeseries.py"
-    nworkers: 8
-    config: "${AQUA_CONFIG}/diagnostics/radiation/config_radiation-timeseries.yaml"
-    outname: radiation
-  teleconnections_atm:
-    script_path: "teleconnections/cli_teleconnections.py"
-    nworkers: 8
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_atm.yaml"
-    outname: teleconnections
-  teleconnections_oce:
-    script_path: "teleconnections/cli_teleconnections.py"
-    nworkers: 4
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_oce.yaml"
-    outname: teleconnections
-  tropical_rainfall:
-    script_path: "../../diagnostics/tropical_rainfall/cli/cli_tropical_rainfall.py"
-    nworkers: 16
-    config: "${AQUA_CONFIG}/diagnostics/tropical_rainfall/cli/cli_config_trop_rainfall.yml"
-    extra: "--regrid=r100 --freq=M --xmax=75 --bufferdir=${OUTPUT}/tropical_rainfall/"
-  ecmean:
-    script_path: "ecmean/cli_ecmean.py"
-    nworkers: 4
-    nocluster: true  # ECmean does not use the global dask cluster
-    source_oce: true  # if a --source_oce argument was passed use it
-    config: "${AQUA_CONFIG}/diagnostics/ecmean/config_ecmean_cli.yaml"
-  ocean3d_drift:
-    script_path: "../../diagnostics/ocean3d/cli/cli_ocean3d.py"
-    nworkers: 8
-    config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.drift.yaml"
-  ocean3d_circulation:
-    script_path: "../../diagnostics/ocean3d/cli/cli_ocean3d.py"
-    nworkers: 4
-    config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.circulation.yaml"
+  atmosphere3d:
+    biases:
+      config: "${AQUA_CONFIG}/diagnostics/atmosphere3d/config-atmosphere3d-era5.yaml"
+
+  climate_metrics:
+    ecmean:
+      config: "${AQUA_CONFIG}/diagnostics/climate_metrics/config-climate_metrics-ecmean.yaml"
+      nocluster: true  # ECmean does not use the global dask cluster
+      source_oce: true  # if a --source_oce argument was passed use it
+    gregory:
+      config: "${AQUA_CONFIG}/diagnostics/climate_metrics/config-climate_metrics-gregory.yaml"
+
+  ocean2d:
+    biases:
+      config: "${AQUA_CONFIG}/diagnostics/ocean2d/config-ocean2d-esacci.yaml"
+
+  ocean3d-part1:
+    trends:
+      config: "${AQUA_CONFIG}/diagnostics/ocean3d/config-ocean3d-en4-trend-drift.yaml"  # these diagnostics need a different chunking
+      outname: "ocean3d"
+    drift:
+      config: "${AQUA_CONFIG}/diagnostics/ocean3d/config-ocean3d-en4-trend-drift.yaml"  # these diagnostics need a different chunking
+      outname: "ocean3d"
+
+  ocean3d-part2:
+    stratification:
+      config: "${AQUA_CONFIG}/diagnostics/ocean3d/config-ocean3d-en4-stratification.yaml"
+      outname: "ocean3d"
+
+  radiation-toa:
+    biases:
+      config: "${AQUA_CONFIG}/diagnostics/radiation_toa/config-radiation_toa-ceres.yaml"
+    boxplots:
+      config: "${AQUA_CONFIG}/diagnostics/radiation_toa/config-radiation_toa-boxplots.yaml"
+    timeseries:
+      config: "${AQUA_CONFIG}/diagnostics/radiation_toa/config-radiation_toa-ceres.yaml"
+
+  radiation-surface:
+    biases:
+      config: ["${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-ceres.yaml",
+               "${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-era5.yaml"]
+    boxplots:
+      config: "${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-boxplots.yaml"
+    timeseries:
+      config: ["${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-ceres.yaml",
+               "${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-era5.yaml"]
+
   seaice:
-    script_path: "seaice/cli_seaice.py"
-    nworkers: 4
-    config: "${AQUA_CONFIG}/diagnostics/seaice/config_seaice.yaml"
+    seaice:
+      config: "${AQUA_CONFIG}/diagnostics/seaice/config-seaice.yaml"
+
+  teleconnections:
+    nao:
+      config: "${AQUA_CONFIG}/diagnostics/teleconnections/config-teleconnections-nao.yaml"
+    enso:
+      config: "${AQUA_CONFIG}/diagnostics/teleconnections/config-teleconnections-enso.yaml"
+
+  water_cycle:
+    timeseries:
+      config: "${AQUA_CONFIG}/diagnostics/water_cycle/config-water_cycle-mswep.yaml"
+    biases:
+      config: "${AQUA_CONFIG}/diagnostics/water_cycle/config-water_cycle-mswep.yaml"
+    lat_lon_profiles:
+      config: "${AQUA_CONFIG}/diagnostics/water_cycle/config-water_cycle-mswep.yaml"
+    tropical_rainfall:
+      config: "${AQUA_CONFIG}/diagnostics/water_cycle/config-water_cycle-tropical_rainfall.yaml"
+      extra: "--regrid=r100 --freq=M --xmax=75 --bufferdir=${OUTPUT}/tropical_rainfall/"

--- a/config/cli_ecefast/config.aqua-analysis.atm.yaml
+++ b/config/cli_ecefast/config.aqua-analysis.atm.yaml
@@ -20,7 +20,7 @@ job:
 
     # Run a check analysis to test the configuration and the presence of needed data
     # This also rebuild the area files, to avoid error with corrupted files
-    run_checker: false
+    run_checker: true
     
     # Default output directory for the analysis. Can be overridden by the command line arguments
     outputdir: "./output"
@@ -61,7 +61,8 @@ cli:
   tropical_rainfall: "../../diagnostics/tropical_rainfall/cli/cli_tropical_rainfall.py"
 
 run: 
-    - ["teleconnections", "climate_metrics", "atmosphere2d", "atmosphere3d"] # very fast ones first, a few min
+    - ["teleconnections", "climate_metrics"] # very fast ones first, a few min
+    - ["atmosphere2d", "atmosphere3d"] 
     - [ "radiation-surface", "radiation-toa"]
 
   # List of diagnostics
@@ -140,8 +141,8 @@ diagnostics:
   teleconnections:
     nao:
       config: "${AQUA_CONFIG}/diagnostics/teleconnections/config-teleconnections-nao.yaml"
-    enso:
-      config: "${AQUA_CONFIG}/diagnostics/teleconnections/config-teleconnections-enso.yaml"
+    #enso:
+    #  config: "${AQUA_CONFIG}/diagnostics/teleconnections/config-teleconnections-enso.yaml"
 
   water_cycle:
     timeseries:

--- a/config/cli_ecefast/config.aqua-analysis.atm.yaml
+++ b/config/cli_ecefast/config.aqua-analysis.atm.yaml
@@ -20,7 +20,7 @@ job:
 
     # Run a check analysis to test the configuration and the presence of needed data
     # This also rebuild the area files, to avoid error with corrupted files
-    run_checker: true
+    run_checker: false
     
     # Default output directory for the analysis. Can be overridden by the command line arguments
     outputdir: "./output"
@@ -34,7 +34,7 @@ job:
     startdate: null
     enddate: null
 
-    script_path_base: "${AQUA}/src/aqua_diagnostics"  # Base directory for the diagnostic scripts
+    script_path_base: "${AQUA_DIAGNOSTICS}/aqua/diagnostics"  # Base directory for the diagnostic scripts
 
 cluster:  # options for dask cluster (this works well on lumi)
     workers: 32

--- a/config/cli_ecefast/config.aqua-analysis.ice.yaml
+++ b/config/cli_ecefast/config.aqua-analysis.ice.yaml
@@ -133,7 +133,8 @@ diagnostics:
 
   seaice:
     seaice:
-      config: "${AQUA_CONFIG}/diagnostics/seaice/config-seaice.yaml"
+      config: ["${AQUA_CONFIG}/diagnostics/seaice/config-seaice-osi.yaml",
+               "${AQUA_CONFIG}/diagnostics/seaice/config-seaice-psc.yaml"]
 
   teleconnections:
     nao:

--- a/config/cli_ecefast/config.aqua-analysis.ice.yaml
+++ b/config/cli_ecefast/config.aqua-analysis.ice.yaml
@@ -20,7 +20,7 @@ job:
 
     # Run a check analysis to test the configuration and the presence of needed data
     # This also rebuild the area files, to avoid error with corrupted files
-    run_checker: true
+    run_checker: false
     
     # Default output directory for the analysis. Can be overridden by the command line arguments
     outputdir: "./output"
@@ -34,7 +34,7 @@ job:
     startdate: null
     enddate: null
 
-    script_path_base: "${AQUA}/src/aqua_diagnostics"  # Base directory for the diagnostic scripts
+    script_path_base: "${AQUA_DIAGNOSTICS}/aqua/diagnostics"  # Base directory for the diagnostic scripts
 
 cluster:  # options for dask cluster (this works well on lumi)
     workers: 32

--- a/config/cli_ecefast/config.aqua-analysis.ice.yaml
+++ b/config/cli_ecefast/config.aqua-analysis.ice.yaml
@@ -4,52 +4,64 @@
 # the config directory (i.e. .aqua/diagnostics) and the output directory respectively
 
 job:
-    # The max_threads variable serves as a mechanism to control the maximum number of threads
-    # i.e. diagnostic scripts that can run concurrently.
-    # - If max_threads is set to 0 or a negative value: There is no limit on the number of threads,
+    # The max_threads variable serves as a mechanism to control the maximum number of diagnostics being run concurrently
+    # - If max_threads is set to 0 or a negative value: There is no limit on the number of parallel diagnostics,
     #                                                   and all processes run in parallel without waiting. 
     #                                                   This is suitable for situations where you want to utilize
     #                                                   the maximum available resources without any restrictions.
-    # - If max_threads is set to a positive value: It limits the number of concurrent threads to the specified value. 
-    #                                              After launching the designated number of threads, the script waits
-    #                                              for these threads to complete before launching additional ones. 
-    #                                              This is useful when you are working on a system with limitations
-    #                                              on the number of concurrent threads, like a login node.
+    # - If max_threads is set to a positive value: It limits the number of concurrent processes to the specified value. 
+    #                                              After launching the designated number of diagnostics, the script waits
+    #                                              for these to complete before launching additional ones. 
+    #                                              This is useful when you are working on a system with limited
+    #                                              resources, such as a login node
 
     max_threads: 0  # Set to the desired maximum number of threads, or leave it as 0 for no limit
     loglevel: "WARNING" # DEBUG, IN FO, WARNING, ERROR, CRITICAL
 
     # Run a check analysis to test the configuration and the presence of needed data
     # This also rebuild the area files, to avoid error with corrupted files
-    run_checker: False
+    run_checker: true
     
     # Default output directory for the analysis. Can be overridden by the command line arguments
-    outputdir: "${AQUA}/cli/aqua-analysis/output" 
+    outputdir: "./output"
 
     # Default values, overriden from command line arguments
     catalog: null  # The catalog to use for the analysis
     model: "IFS-NEMO"
     exp: "historical-1990"
     source: "lra-r100-monthly"
+    regrid: null
+    startdate: null
+    enddate: null
 
     script_path_base: "${AQUA}/src/aqua_diagnostics"  # Base directory for the diagnostic scripts
 
 cluster:  # options for dask cluster (this works well on lumi)
     workers: 32
-    threads: 2  # per worker
+    threads: 1  # per worker
     memory_limit: 7GiB  # per worker
+    connect_timeout: 120  # seconds to wait for client to connect to the cluster
+    # ftp_timeout: 60  # timeout in seconds for ftp connections. Will not be set if omitted.
 
-diagnostics:
+# List of available CLI tools (diagnostics)
+cli:
+  biases: "global_biases/cli_global_biases.py"
+  boxplots: "boxplots/cli_boxplots.py"
+  drift: "ocean_drift/cli_ocean_drift.py"
+  ecmean: "ecmean/cli_ecmean.py"
+  enso: "teleconnections/cli_teleconnections.py"
+  gregory: "timeseries/cli_timeseries.py"
+  lat_lon_profiles: "lat_lon_profiles/cli_lat_lon_profiles.py"
+  nao: "teleconnections/cli_teleconnections.py"
+  seaice: "seaice/cli_seaice.py"
+  seasonal_cycles: "timeseries/cli_timeseries.py"  # not used
+  stratification: "ocean_stratification/cli_ocean_stratification.py"
+  timeseries: "timeseries/cli_timeseries.py"
+  trends: "ocean_trends/cli_ocean_trends.py"
+  tropical_rainfall: "../../diagnostics/tropical_rainfall/cli/cli_tropical_rainfall.py"
 
-  # List of diagnostics to run
-  # run: ["global_biases", "timeseries_atm", "timeseries_oce", "seasonal_cycles",
-  #       "radiation-boxplots", "radiation-timeseries", "radiation-biases", 
-  #       "teleconnections_atm", "teleconnections_oce",
-  #       "tropical_rainfall", "ecmean", "ocean3d_drift", "ocean3d_circulation",
-  #       "seaice_volume", "seaice_thick", "seaice_conc", "seaice_extent"]
-
-  run: ["seaice"]
-
+run: 
+    - ["seaice"]
   # List of diagnostics
 
   # Each diagnostic can have the following options (all optional):
@@ -61,71 +73,81 @@ diagnostics:
   #    script_path: the location of the script to run the diagnostic.
   #                 Default script_path is "$script_path_base/$diagnostic/cli/cli_${diagnostic}.py"
   #    nocluster: boolean, if set to true, the diagnostic will not use the global dask cluster. Default is false (needed for ECmean)
+diagnostics:
+  atmosphere2d: 
+    biases: 
+      config: ["${AQUA_CONFIG}/diagnostics/atmosphere2d/config-atmosphere2d-berkeley.yaml", 
+               "${AQUA_CONFIG}/diagnostics/atmosphere2d/config-atmosphere2d-era5.yaml"]
+    timeseries:
+      config: ["${AQUA_CONFIG}/diagnostics/atmosphere2d/config-atmosphere2d-berkeley.yaml",
+               "${AQUA_CONFIG}/diagnostics/atmosphere2d/config-atmosphere2d-era5.yaml"]
+    lat_lon_profiles:
+      config: "${AQUA_CONFIG}/diagnostics/atmosphere2d/config-atmosphere2d-berkeley.yaml"
 
-  global_biases:
-    nworkers: 16
-    script_path: "global_biases/cli_global_biases.py"
-    config: "${AQUA_CONFIG}/diagnostics/global_biases/cli/config_global_biases.yaml"
-  timeseries_atm:
-    script_path: "timeseries/cli_timeseries.py"
-    config: "${AQUA_CONFIG}/diagnostics/timeseries/config_timeseries_atm.yaml"
-    nworkers: 16
-    outname: timeseries
-  timeseries_oce:
-    script_path: "timeseries/cli_timeseries.py"
-    config: "${AQUA_CONFIG}/diagnostics/timeseries/config_timeseries_oce.yaml"
-    nworkers: 8
-    outname: timeseries
-  seasonal_cycles:
-    script_path: "timeseries/cli_timeseries.py"
-    nworkers: 16
-    config: "${AQUA_CONFIG}/diagnostics/timeseries/config_seasonalcycles_atm.yaml"
-    outname: timeseries
-  radiation-biases:
-    script_path: "global_biases/cli_global_biases.py"
-    nworkers: 8
-    config: "${AQUA_CONFIG}/diagnostics/radiation/cli/config_radiation-biases.yaml"
-    outname: radiation
-  radiation-boxplots:
-    script_path: "boxplots/cli_boxplots.py"
-    nworkers: 8
-    config: "${AQUA_CONFIG}/diagnostics/radiation/cli/config_radiation-boxplots.yaml"
-    outname: radiation
-  radiation-timeseries:
-    script_path: "timeseries/cli_timeseries.py"
-    nworkers: 8
-    config: "${AQUA_CONFIG}/diagnostics/radiation/cli/config_radiation-timeseries.yaml"
-    outname: radiation
-  teleconnections_atm:
-    script_path: "teleconnections/cli_teleconnections.py"
-    nworkers: 8
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_atm.yaml"
-    outname: teleconnections
-  teleconnections_oce:
-    script_path: "teleconnections/cli_teleconnections.py"
-    nworkers: 4
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_oce.yaml"
-    outname: teleconnections
-  tropical_rainfall:
-    script_path: "../../diagnostics/tropical_rainfall/cli/cli_tropical_rainfall.py"
-    nworkers: 16
-    config: "${AQUA_CONFIG}/diagnostics/tropical_rainfall/cli/cli_config_trop_rainfall.yml"
-    extra: "--regrid=r100 --freq=M --xmax=75 --bufferdir=${OUTPUT}/tropical_rainfall/"
-  ecmean:
-    script_path: "ecmean/cli_ecmean.py"
-    nworkers: 4
-    nocluster: true  # ECmean does not use the global dask cluster
-    source_oce: true  # if a --source_oce argument was passed use it
-    config: "${AQUA_CONFIG}/diagnostics/ecmean/config_ecmean_cli.yaml"
-  ocean3d_drift:
-    script_path: "../../diagnostics/ocean3d/cli/cli_ocean3d.py"
-    nworkers: 8
-    config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.drift.yaml"
-  ocean3d_circulation:
-    script_path: "../../diagnostics/ocean3d/cli/cli_ocean3d.py"
-    nworkers: 4
-    config: "${AQUA_CONFIG}/diagnostics/ocean3d/cli/config.circulation.yaml"
+  atmosphere3d:
+    biases:
+      config: "${AQUA_CONFIG}/diagnostics/atmosphere3d/config-atmosphere3d-era5.yaml"
+
+  climate_metrics:
+    ecmean:
+      config: "${AQUA_CONFIG}/diagnostics/climate_metrics/config-climate_metrics-ecmean.yaml"
+      nocluster: true  # ECmean does not use the global dask cluster
+      source_oce: true  # if a --source_oce argument was passed use it
+    gregory:
+      config: "${AQUA_CONFIG}/diagnostics/climate_metrics/config-climate_metrics-gregory.yaml"
+
+  ocean2d:
+    biases:
+      config: "${AQUA_CONFIG}/diagnostics/ocean2d/config-ocean2d-esacci.yaml"
+
+  ocean3d-part1:
+    trends:
+      config: "${AQUA_CONFIG}/diagnostics/ocean3d/config-ocean3d-en4-trend-drift.yaml"  # these diagnostics need a different chunking
+      outname: "ocean3d"
+    drift:
+      config: "${AQUA_CONFIG}/diagnostics/ocean3d/config-ocean3d-en4-trend-drift.yaml"  # these diagnostics need a different chunking
+      outname: "ocean3d"
+
+  ocean3d-part2:
+    stratification:
+      config: "${AQUA_CONFIG}/diagnostics/ocean3d/config-ocean3d-en4-stratification.yaml"
+      outname: "ocean3d"
+
+  radiation-toa:
+    biases:
+      config: "${AQUA_CONFIG}/diagnostics/radiation_toa/config-radiation_toa-ceres.yaml"
+    boxplots:
+      config: "${AQUA_CONFIG}/diagnostics/radiation_toa/config-radiation_toa-boxplots.yaml"
+    timeseries:
+      config: "${AQUA_CONFIG}/diagnostics/radiation_toa/config-radiation_toa-ceres.yaml"
+
+  radiation-surface:
+    biases:
+      config: ["${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-ceres.yaml",
+               "${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-era5.yaml"]
+    boxplots:
+      config: "${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-boxplots.yaml"
+    timeseries:
+      config: ["${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-ceres.yaml",
+               "${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-era5.yaml"]
+
   seaice:
-    script_path: "seaice/cli_seaice.py"
-    nworkers: 4
-    config: "${AQUA_CONFIG}/diagnostics/seaice/config_seaice.yaml"
+    seaice:
+      config: "${AQUA_CONFIG}/diagnostics/seaice/config-seaice.yaml"
+
+  teleconnections:
+    nao:
+      config: "${AQUA_CONFIG}/diagnostics/teleconnections/config-teleconnections-nao.yaml"
+    enso:
+      config: "${AQUA_CONFIG}/diagnostics/teleconnections/config-teleconnections-enso.yaml"
+
+  water_cycle:
+    timeseries:
+      config: "${AQUA_CONFIG}/diagnostics/water_cycle/config-water_cycle-mswep.yaml"
+    biases:
+      config: "${AQUA_CONFIG}/diagnostics/water_cycle/config-water_cycle-mswep.yaml"
+    lat_lon_profiles:
+      config: "${AQUA_CONFIG}/diagnostics/water_cycle/config-water_cycle-mswep.yaml"
+    tropical_rainfall:
+      config: "${AQUA_CONFIG}/diagnostics/water_cycle/config-water_cycle-tropical_rainfall.yaml"
+      extra: "--regrid=r100 --freq=M --xmax=75 --bufferdir=${OUTPUT}/tropical_rainfall/"

--- a/config/cli_ecefast/config.aqua-analysis.oce.yaml
+++ b/config/cli_ecefast/config.aqua-analysis.oce.yaml
@@ -61,7 +61,8 @@ cli:
   tropical_rainfall: "../../diagnostics/tropical_rainfall/cli/cli_tropical_rainfall.py"
 
 run: 
-  - ["ocean2d", "ocean3d-part1",  "ocean3d-part2"]
+  - ["teleconnections", "ocean2d"] #3d ocean is broken for now
+  #- ["ocean3d-part1",  "ocean3d-part2"]
   # List of diagnostics
 
   # Each diagnostic can have the following options (all optional):
@@ -133,11 +134,12 @@ diagnostics:
 
   seaice:
     seaice:
-      config: "${AQUA_CONFIG}/diagnostics/seaice/config-seaice.yaml"
+      config: ["${AQUA_CONFIG}/diagnostics/seaice/config-seaice-osi.yaml",
+               "${AQUA_CONFIG}/diagnostics/seaice/config-seaice-psc.yaml"]
 
   teleconnections:
-    nao:
-      config: "${AQUA_CONFIG}/diagnostics/teleconnections/config-teleconnections-nao.yaml"
+    #nao:
+    #  config: "${AQUA_CONFIG}/diagnostics/teleconnections/config-teleconnections-nao.yaml"
     enso:
       config: "${AQUA_CONFIG}/diagnostics/teleconnections/config-teleconnections-enso.yaml"
 

--- a/config/cli_ecefast/config.aqua-analysis.oce.yaml
+++ b/config/cli_ecefast/config.aqua-analysis.oce.yaml
@@ -20,7 +20,7 @@ job:
 
     # Run a check analysis to test the configuration and the presence of needed data
     # This also rebuild the area files, to avoid error with corrupted files
-    run_checker: true
+    run_checker: false
     
     # Default output directory for the analysis. Can be overridden by the command line arguments
     outputdir: "./output"
@@ -34,7 +34,7 @@ job:
     startdate: null
     enddate: null
 
-    script_path_base: "${AQUA}/src/aqua_diagnostics"  # Base directory for the diagnostic scripts
+    script_path_base: "${AQUA_DIAGNOSTICS}/aqua/diagnostics"  # Base directory for the diagnostic scripts
 
 cluster:  # options for dask cluster (this works well on lumi)
     workers: 32

--- a/config/cli_ecefast/config.aqua-analysis.oce.yaml
+++ b/config/cli_ecefast/config.aqua-analysis.oce.yaml
@@ -4,52 +4,64 @@
 # the config directory (i.e. .aqua/diagnostics) and the output directory respectively
 
 job:
-    # The max_threads variable serves as a mechanism to control the maximum number of threads
-    # i.e. diagnostic scripts that can run concurrently.
-    # - If max_threads is set to 0 or a negative value: There is no limit on the number of threads,
+    # The max_threads variable serves as a mechanism to control the maximum number of diagnostics being run concurrently
+    # - If max_threads is set to 0 or a negative value: There is no limit on the number of parallel diagnostics,
     #                                                   and all processes run in parallel without waiting. 
     #                                                   This is suitable for situations where you want to utilize
     #                                                   the maximum available resources without any restrictions.
-    # - If max_threads is set to a positive value: It limits the number of concurrent threads to the specified value. 
-    #                                              After launching the designated number of threads, the script waits
-    #                                              for these threads to complete before launching additional ones. 
-    #                                              This is useful when you are working on a system with limitations
-    #                                              on the number of concurrent threads, like a login node.
+    # - If max_threads is set to a positive value: It limits the number of concurrent processes to the specified value. 
+    #                                              After launching the designated number of diagnostics, the script waits
+    #                                              for these to complete before launching additional ones. 
+    #                                              This is useful when you are working on a system with limited
+    #                                              resources, such as a login node
 
     max_threads: 0  # Set to the desired maximum number of threads, or leave it as 0 for no limit
     loglevel: "WARNING" # DEBUG, IN FO, WARNING, ERROR, CRITICAL
 
     # Run a check analysis to test the configuration and the presence of needed data
     # This also rebuild the area files, to avoid error with corrupted files
-    run_checker: True
+    run_checker: true
     
     # Default output directory for the analysis. Can be overridden by the command line arguments
-    outputdir: "${AQUA}/cli/aqua-analysis/output" 
+    outputdir: "./output"
 
     # Default values, overriden from command line arguments
     catalog: null  # The catalog to use for the analysis
     model: "IFS-NEMO"
     exp: "historical-1990"
     source: "lra-r100-monthly"
+    regrid: null
+    startdate: null
+    enddate: null
 
     script_path_base: "${AQUA}/src/aqua_diagnostics"  # Base directory for the diagnostic scripts
 
 cluster:  # options for dask cluster (this works well on lumi)
     workers: 32
-    threads: 2  # per worker
+    threads: 1  # per worker
     memory_limit: 7GiB  # per worker
+    connect_timeout: 120  # seconds to wait for client to connect to the cluster
+    # ftp_timeout: 60  # timeout in seconds for ftp connections. Will not be set if omitted.
 
-diagnostics:
+# List of available CLI tools (diagnostics)
+cli:
+  biases: "global_biases/cli_global_biases.py"
+  boxplots: "boxplots/cli_boxplots.py"
+  drift: "ocean_drift/cli_ocean_drift.py"
+  ecmean: "ecmean/cli_ecmean.py"
+  enso: "teleconnections/cli_teleconnections.py"
+  gregory: "timeseries/cli_timeseries.py"
+  lat_lon_profiles: "lat_lon_profiles/cli_lat_lon_profiles.py"
+  nao: "teleconnections/cli_teleconnections.py"
+  seaice: "seaice/cli_seaice.py"
+  seasonal_cycles: "timeseries/cli_timeseries.py"  # not used
+  stratification: "ocean_stratification/cli_ocean_stratification.py"
+  timeseries: "timeseries/cli_timeseries.py"
+  trends: "ocean_trends/cli_ocean_trends.py"
+  tropical_rainfall: "../../diagnostics/tropical_rainfall/cli/cli_tropical_rainfall.py"
 
-  # List of diagnostics to run
-  # run: ["global_biases", "timeseries_atm", "timeseries_oce", "seasonal_cycles",
-  #       "radiation-boxplots", "radiation-timeseries", "radiation-biases", 
-  #       "teleconnections_atm", "teleconnections_oce",
-  #       "tropical_rainfall", "ecmean", "ocean3d_drift", "ocean3d_circulation",
-  #       "seaice_volume", "seaice_thick", "seaice_conc", "seaice_extent"]
-
-  run: ["ocean3d_drift", "ocean3d_circulation", "timeseries_oce"]
-
+run: 
+  - ["ocean2d", "ocean3d-part1",  "ocean3d-part2"]
   # List of diagnostics
 
   # Each diagnostic can have the following options (all optional):
@@ -61,71 +73,81 @@ diagnostics:
   #    script_path: the location of the script to run the diagnostic.
   #                 Default script_path is "$script_path_base/$diagnostic/cli/cli_${diagnostic}.py"
   #    nocluster: boolean, if set to true, the diagnostic will not use the global dask cluster. Default is false (needed for ECmean)
+diagnostics:
+  atmosphere2d: 
+    biases: 
+      config: ["${AQUA_CONFIG}/diagnostics/atmosphere2d/config-atmosphere2d-berkeley.yaml", 
+               "${AQUA_CONFIG}/diagnostics/atmosphere2d/config-atmosphere2d-era5.yaml"]
+    timeseries:
+      config: ["${AQUA_CONFIG}/diagnostics/atmosphere2d/config-atmosphere2d-berkeley.yaml",
+               "${AQUA_CONFIG}/diagnostics/atmosphere2d/config-atmosphere2d-era5.yaml"]
+    lat_lon_profiles:
+      config: "${AQUA_CONFIG}/diagnostics/atmosphere2d/config-atmosphere2d-berkeley.yaml"
 
-  global_biases:
-    nworkers: 16
-    script_path: "global_biases/cli_global_biases.py"
-    config: "${AQUA_CONFIG}/diagnostics/global_biases/cli/config_global_biases.yaml"
-  timeseries_atm:
-    script_path: "timeseries/cli_timeseries.py"
-    config: "${AQUA_CONFIG}/diagnostics/timeseries/config_timeseries_atm.yaml"
-    nworkers: 16
-    outname: timeseries
-  timeseries_oce:
-    script_path: "timeseries/cli_timeseries.py"
-    config: "${AQUA_CONFIG}/diagnostics/timeseries/config_timeseries_oce.yaml"
-    nworkers: 8
-    outname: timeseries
-  seasonal_cycles:
-    script_path: "timeseries/cli_timeseries.py"
-    nworkers: 16
-    config: "${AQUA_CONFIG}/diagnostics/timeseries/config_seasonalcycles_atm.yaml"
-    outname: timeseries
-  radiation-biases:
-    script_path: "global_biases/cli_global_biases.py"
-    nworkers: 8
-    config: "${AQUA_CONFIG}/diagnostics/radiation/cli/config_radiation-biases.yaml"
-    outname: radiation
-  radiation-boxplots:
-    script_path: "boxplots/cli_boxplots.py"
-    nworkers: 8
-    config: "${AQUA_CONFIG}/diagnostics/radiation/cli/config_radiation-boxplots.yaml"
-    outname: radiation
-  radiation-timeseries:
-    script_path: "timeseries/cli_timeseries.py"
-    nworkers: 8
-    config: "${AQUA_CONFIG}/diagnostics/radiation/cli/config_radiation-timeseries.yaml"
-    outname: radiation
-  teleconnections_atm:
-    script_path: "teleconnections/cli_teleconnections.py"
-    nworkers: 8
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_atm.yaml"
-    outname: teleconnections
-  teleconnections_oce:
-    script_path: "teleconnections/cli_teleconnections.py"
-    nworkers: 4
-    config: "${AQUA_CONFIG}/diagnostics/teleconnections/config_teleconnections_oce.yaml"
-    outname: teleconnections
-  tropical_rainfall:
-    script_path: "../../diagnostics/tropical_rainfall/cli/cli_tropical_rainfall.py"
-    nworkers: 16
-    config: "${AQUA_CONFIG}/diagnostics/tropical_rainfall/cli/cli_config_trop_rainfall.yml"
-    extra: "--regrid=r100 --freq=M --xmax=75 --bufferdir=${OUTPUT}/tropical_rainfall/"
-  ecmean:
-    script_path: "ecmean/cli_ecmean.py"
-    nworkers: 4
-    nocluster: true  # ECmean does not use the global dask cluster
-    source_oce: true  # if a --source_oce argument was passed use it
-    config: "${AQUA_CONFIG}/diagnostics/ecmean/config_ecmean_cli.yaml"
-  ocean3d_drift:
-    script_path: "../../diagnostics/ocean3d/cli/cli_ocean3d.py"
-    nworkers: 8
-    config: "${AQUA_CONFIG}/diagnostics/ocean3d/config.drift.yaml"
-  ocean3d_circulation:
-    script_path: "../../diagnostics/ocean3d/cli/cli_ocean3d.py"
-    nworkers: 4
-    config: "${AQUA_CONFIG}/diagnostics/ocean3d/config.circulation.yaml"
+  atmosphere3d:
+    biases:
+      config: "${AQUA_CONFIG}/diagnostics/atmosphere3d/config-atmosphere3d-era5.yaml"
+
+  climate_metrics:
+    ecmean:
+      config: "${AQUA_CONFIG}/diagnostics/climate_metrics/config-climate_metrics-ecmean.yaml"
+      nocluster: true  # ECmean does not use the global dask cluster
+      source_oce: true  # if a --source_oce argument was passed use it
+    gregory:
+      config: "${AQUA_CONFIG}/diagnostics/climate_metrics/config-climate_metrics-gregory.yaml"
+
+  ocean2d:
+    biases:
+      config: "${AQUA_CONFIG}/diagnostics/ocean2d/config-ocean2d-esacci.yaml"
+
+  ocean3d-part1:
+    trends:
+      config: "${AQUA_CONFIG}/diagnostics/ocean3d/config-ocean3d-en4-trend-drift.yaml"  # these diagnostics need a different chunking
+      outname: "ocean3d"
+    drift:
+      config: "${AQUA_CONFIG}/diagnostics/ocean3d/config-ocean3d-en4-trend-drift.yaml"  # these diagnostics need a different chunking
+      outname: "ocean3d"
+
+  ocean3d-part2:
+    stratification:
+      config: "${AQUA_CONFIG}/diagnostics/ocean3d/config-ocean3d-en4-stratification.yaml"
+      outname: "ocean3d"
+
+  radiation-toa:
+    biases:
+      config: "${AQUA_CONFIG}/diagnostics/radiation_toa/config-radiation_toa-ceres.yaml"
+    boxplots:
+      config: "${AQUA_CONFIG}/diagnostics/radiation_toa/config-radiation_toa-boxplots.yaml"
+    timeseries:
+      config: "${AQUA_CONFIG}/diagnostics/radiation_toa/config-radiation_toa-ceres.yaml"
+
+  radiation-surface:
+    biases:
+      config: ["${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-ceres.yaml",
+               "${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-era5.yaml"]
+    boxplots:
+      config: "${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-boxplots.yaml"
+    timeseries:
+      config: ["${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-ceres.yaml",
+               "${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-era5.yaml"]
+
   seaice:
-    script_path: "seaice/cli_seaice.py"
-    nworkers: 4
-    config: "${AQUA_CONFIG}/diagnostics/seaice/config_seaice.yaml"
+    seaice:
+      config: "${AQUA_CONFIG}/diagnostics/seaice/config-seaice.yaml"
+
+  teleconnections:
+    nao:
+      config: "${AQUA_CONFIG}/diagnostics/teleconnections/config-teleconnections-nao.yaml"
+    enso:
+      config: "${AQUA_CONFIG}/diagnostics/teleconnections/config-teleconnections-enso.yaml"
+
+  water_cycle:
+    timeseries:
+      config: "${AQUA_CONFIG}/diagnostics/water_cycle/config-water_cycle-mswep.yaml"
+    biases:
+      config: "${AQUA_CONFIG}/diagnostics/water_cycle/config-water_cycle-mswep.yaml"
+    lat_lon_profiles:
+      config: "${AQUA_CONFIG}/diagnostics/water_cycle/config-water_cycle-mswep.yaml"
+    tropical_rainfall:
+      config: "${AQUA_CONFIG}/diagnostics/water_cycle/config-water_cycle-tropical_rainfall.yaml"
+      extra: "--regrid=r100 --freq=M --xmax=75 --bufferdir=${OUTPUT}/tropical_rainfall/"

--- a/config/config_ecefast/diagnostics/radiation/config_radiation-boxplots.yaml
+++ b/config/config_ecefast/diagnostics/radiation/config_radiation-boxplots.yaml
@@ -41,4 +41,6 @@ diagnostics:
     run: true
     diagnostic_name: 'radiation'
     variables:  
-      - ['-tnlwrf', 'tnswrf']
+      - vars: ['-tnlwrf', 'tnswrf']
+        anomalies: True
+        add_mean_line: True

--- a/jobs/aqua_analysis.tmpl
+++ b/jobs/aqua_analysis.tmpl
@@ -9,15 +9,17 @@
 #SBATCH --chdir=/ec/res4/scratch/<YOURUSER>/aqua
 #SBATCH --qos=express
 #SBATCH --time=02:30:00
-#SBATCH --mail-type=FAIL
-
-###SBATCH --mem=239G
+#SBATCH --mem=230G
+###SBATCH --mail-type=FAIL
 set -eo
 
 catalog=<catalog> # available are ece4-tuning, epochal, antarctic-mwe
 model=<model> # available are EC-EARTH4, ECE-FAST
 exp=<experiment>
-regrid=<regrid> # we suggest 'r100' for EC-EARTH4 and 'r200' for ECE-FAST. False to deactivate regridding
+regrid=<regrid> # we suggest 'r100' for EC-EARTH4 and 'r200' for ECE-FAST. False to deactivate regridding. ECmean will not work with `r200` 
+startdate=<startdate>
+enddate=<enddate>
+PUSH_ANALYSIS_DIR=/ec/res4/hpcperm/ccjh/AQUA/cli/aqua-web
 
 # This for HPC2020, if you have a conda environment, you should comment this line
 # and load the environment in the next line
@@ -26,9 +28,9 @@ tykky activate aqua
 
 amip=false
 
-OUTDIR=/ec/res4/scratch/<YOURUSER>/aqua-analysis
+OUTDIR=/ec/res4/scratch/ccpd/aqua-analysis
 mkdir -p $OUTDIR
-CONFIG_DIR=<PATH_TO_ECE-CATALOG_REPO>/config # note the change of path from the previous version
+CONFIG_DIR=/home/ccpd/perm/ece-catalogue/config # note the change of path from the previous version
 
 if [ "$model" = "EC-EARTH4" ] && [[ "$catalog" = "$antarctic-mwe" ]]; then
     configatm=$CONFIG_DIR/cli_antarctic-mwe/config.aqua-analysis.atm.yaml
@@ -50,11 +52,10 @@ else
 fi
 
 # We use three different scripts because they all use different sources
-aqua analysis -l debug -c $catalog -m $model -e $exp -s monthly-atm -d $OUTDIR -p --config $configatm --regrid $regrid
+aqua analysis -l debug -c $catalog -m $model -e $exp -s monthly-atm -d $OUTDIR -p --config $configatm --regrid $regrid --startdate $startdate --enddate $enddate
 if [ "$amip" = false ]; then
-    aqua analysis -l debug -c $catalog -m $model -e $exp -s monthly-oce -d $OUTDIR -p --config $configoce --regrid $regrid
-    aqua analysis -l debug -c $catalog -m $model -e $exp -s monthly-ice -d $OUTDIR -p --config $configice --regrid $regrid
+    aqua analysis -l debug -c $catalog -m $model -e $exp -s monthly-oce -d $OUTDIR -p --config $configoce --regrid $regrid --startdate $startdate --enddate $enddate
+    aqua analysis -l debug -c $catalog -m $model -e $exp -s monthly-ice -d $OUTDIR -p --config $configice --regrid $regrid --startdate $startdate --enddate $enddate
 fi
 
-#cd /ec/res4/hpcperm/ccjh/AQUA/cli/aqua-web
-#./push_analysis.sh --rsync jost@wilma.to.isac.cnr.it:work/aqua/upload -c  /home/ccjh/hpcperm/AQUA/cli/aqua-web/config.grouping.yaml  $SCRATCH/aqua-analysis atos/EC-EARTH4/$exp
+bash ${PUSH_ANALYSIS_DIR}/push_analysis.sh --rsync aqua@climate-web.polito.it:ece4 -c /home/ccjh/hpcperm/AQUA/cli/aqua-web/config.grouping.yaml  $SCRATCH/aqua-analysis  ece4-tuning/$model/$exp/r1

--- a/jobs/aqua_analysis.tmpl
+++ b/jobs/aqua_analysis.tmpl
@@ -58,4 +58,4 @@ if [ "$amip" = false ]; then
     aqua analysis -l debug -c $catalog -m $model -e $exp -s monthly-ice -d $OUTDIR -p --config $configice --regrid $regrid --startdate $startdate --enddate $enddate
 fi
 
-bash ${PUSH_ANALYSIS_DIR}/push_analysis.sh --rsync aqua@climate-web.polito.it:ece4 -c /home/ccjh/hpcperm/AQUA/cli/aqua-web/config.grouping.yaml  $SCRATCH/aqua-analysis  ece4-tuning/$model/$exp/r1
+bash ${PUSH_ANALYSIS_DIR}/push_analysis.sh --rsync aqua@climate-web.polito.it:ece4 -c ${PERM}/AQUA-diagnostics/aqua/diagnostics/config/analysis/config.grouping.yaml  $SCRATCH/aqua-analysis  ece4-tuning/$model/$exp/r1


### PR DESCRIPTION
This PR introduces a refined template with the right aqua web push command working HPC2020. 

Updates the catalog and the script with 3 test experiments, one for Paleorca present day and two for ORCA2 standard configuration (on with overshooting 2262 year for pandas testing)

It updates the aqua-analysis so that it is working again with AQUA v0.21.0
