### PR TITLE
Implement regridding in all diagnostics to avoid mismatches of long values' precision.

### DIFF
--- a/config/cli_nord4/config.aqua-analysis.atm.yaml
+++ b/config/cli_nord4/config.aqua-analysis.atm.yaml
@@ -130,6 +130,8 @@ diagnostics:
       config: "${AQUA_CONFIG}/diagnostics/climate_metrics/config-climate_metrics-ecmean.yaml"
       nocluster: true  # ECmean does not use the global dask cluster
       source_oce: true  # if a --source_oce argument was passed use it
+      extra: "--regrid=r100"
+
     gregory:
       config: "${AQUA_CONFIG}/diagnostics/climate_metrics/config-climate_metrics-gregory.yaml"
 
@@ -174,9 +176,11 @@ diagnostics:
   radiation-surface:  # problem with the calender time is mid-month 
     boxplots:
       config: "${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-boxplots.yaml"
+      extra: "--regrid=r100"
     timeseries:
       config: ["${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-ceres.yaml",
                "${AQUA_CONFIG}/diagnostics/radiation_surface/config-radiation_surface-era5.yaml"]
+      extra: "--regrid=r100"
 
   seaice:
     seaice:

--- a/config/cli_nord4/config.aqua-analysis.atm.yaml
+++ b/config/cli_nord4/config.aqua-analysis.atm.yaml
@@ -134,7 +134,7 @@ diagnostics:
 
     gregory:
       config: "${AQUA_CONFIG}/diagnostics/climate_metrics/config-climate_metrics-gregory.yaml"
-
+      extra: "--regrid=r100"
   # ocean2d-biases:  #disabling since tos is not availavle in atm
   #   biases:
   #     config: "${AQUA_CONFIG}/diagnostics/ocean2d/config-ocean2d-esacci.yaml"


### PR DESCRIPTION
Implement regridding in all diagnostics to avoid mismatches of long values' precision, discussed https://gitlab.earth.bsc.es/es/auto-ecearth4/-/issues/123#note_464832